### PR TITLE
swap step_next and end_workflow

### DIFF
--- a/lib/floe/workflow/state.rb
+++ b/lib/floe/workflow/state.rb
@@ -44,6 +44,7 @@ module Floe
         end
       end
 
+      # @return for incomplete Errno::EAGAIN, for completed 0
       def run_nonblock!
         start(context.input) unless started?
         return Errno::EAGAIN unless ready?


### PR DESCRIPTION
Not sure if we should merge as it is...
This is just to illustrate the problem to give pointers.

`step_next` was setting a next (possibly to nil)
But it wasn't actually running that step yet

The state was not getting a start time and all was marked as complete. So essentially it was skipping the last state if it is a non-wait state (e.g.: pass, success, ...)

end_workflow got confused and thought the next_step had been run, so it marked as complete and never runs it.

I'm thinking the manipulation of history and the like should be in a different method, but I got it down to the lowest set of code.

This removes the `context.state_finished?` per request.
and gets us stepping after completing the state
and gets `end_workflow` to a place that it can be made private
(sorry, start_workflow is not there yet. soon?...)


minimal change:

```diff
      if context.state_finished?
+       end_workflow
        step_next
-       end_workflow
      end
```